### PR TITLE
Enable using host machine nuget packages

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -21,6 +21,10 @@ GO_ARGS = [
     "-go_naming_convention=import",
 ]
 
+DOTNET_ARGS = [
+    "-deps_macro=deps/nuget.bzl%nuget_deps",
+]
+
 # for when the dotnet language is broken
 gazelle(
     name = "gazelle_go",
@@ -29,9 +33,7 @@ gazelle(
 
 gazelle(
     name = "gazelle",
-    args = [
-        "-deps_macro=deps/nuget.bzl%nuget_deps",
-    ] + GO_ARGS,
+    args = DOTNET_ARGS + GO_ARGS,
     gazelle = ":gazelle_local",
 )
 
@@ -44,8 +46,6 @@ gazelle_binary(
 
 gazelle(
     name = "gazelle-dotnet",
-    args = [
-        "-deps_macro=deps/nuget.bzl%nuget_deps",
-    ],
+    args = DOTNET_ARGS,
     gazelle = "//gazelle/dotnet:gazelle-dotnet",
 )

--- a/deps/nuget.bzl
+++ b/deps/nuget.bzl
@@ -3,6 +3,7 @@ load("@my_rules_dotnet//dotnet:defs.bzl", "nuget_fetch")
 def nuget_deps():
     nuget_fetch(
         name = "nuget",
+        use_host = True,
         packages = {
             "CommandLineParser:2.9.0-preview1": ["netcoreapp3.1"],  # keep
             # test deps

--- a/dotnet/private/toolchain/BUILD.nuget.bazel
+++ b/dotnet/private/toolchain/BUILD.nuget.bazel
@@ -4,7 +4,7 @@ package(default_visibility = ["//visibility:public"])
 
 tfm_mapping(
     name = "tfm_mapping",
-    tfm_mapping = {tfm_mapping}
+    tfm_mapping = {tfm_mapping},
 )
 
 alias(
@@ -14,4 +14,6 @@ alias(
 
 exports_files(["{nuget_build_config}"])
 
-exports_files(glob(["packages/**/*"]))
+# this file list looks pretty crazy, but because we list every file specifically, bazel doesn't have to perform a glob
+# of the file system and read the packages directory itself.
+exports_files({file_list})

--- a/dotnet/private/toolchain/BUILD.nuget_import.bazel
+++ b/dotnet/private/toolchain/BUILD.nuget_import.bazel
@@ -1,16 +1,16 @@
-load("@my_rules_dotnet//dotnet:defs.bzl", "nuget_import", "nuget_filegroup")
+load("@my_rules_dotnet//dotnet:defs.bzl", "nuget_filegroup", "nuget_import")
 
 package(default_visibility = ["//visibility:public"])
 
 nuget_import(
     name = "{name}",
-    version = "{version}",
-    frameworks = [
-        "{frameworks}",
-    ],
     all_files = [
         "{all_files}",
     ],
+    frameworks = [
+        "{frameworks}",
+    ],
+    version = "{version}",
 )
 
 {framework_filegroups}

--- a/dotnet/private/toolchain/BUILD.sdk.bazel
+++ b/dotnet/private/toolchain/BUILD.sdk.bazel
@@ -1,18 +1,19 @@
-load("@my_rules_dotnet//dotnet:defs.bzl", "declare_toolchains", "dotnet_sdk", "dotnet_tool_binary", "dotnet_config")
+load("@my_rules_dotnet//dotnet:defs.bzl", "declare_toolchains", "dotnet_config", "dotnet_sdk", "dotnet_tool_binary")
 
 package(default_visibility = ["//visibility:public"])
 
 # https://docs.microsoft.com/en-us/dotnet/core/distribution-packaging
 
 declare_toolchains(
+    builder = ":builder",
     host = "{dotnetos}_{dotnetarch}",
     sdk = ":dotnet_sdk",
-    builder = ":builder",
 )
 
 dotnet_sdk(
     name = "dotnet_sdk",
     all_files = ":all_files",
+    config = ":dotnet_config",
     dotnet = "dotnet{exe}",
     dotnetarch = "{dotnetarch}",
     dotnetos = "{dotnetos}",
@@ -25,22 +26,21 @@ dotnet_sdk(
     sdk_files = ":sdk_files",
     sdk_root = "sdk/{version}",
     shared = {shared},
-    config = ":dotnet_config",
 )
 
 dotnet_config(
     name = "dotnet_config",
-    trim_path = "{trim_path}",
     nuget_config = "{nuget_config}",
-    tfm_mapping = "{tfm_mapping}",
     test_logger = "@{nuget_repo}//:test_logger",
+    tfm_mapping = "{tfm_mapping}",
+    trim_path = "{trim_path}",
 )
 
 dotnet_tool_binary(
     name = "builder",
     srcs = ["@my_rules_dotnet//dotnet/tools/builder:builder_srcs"],
+    dotnet_sdk = ":dotnet_sdk",
     target_framework = "netcoreapp3.1",
-    dotnet_sdk = ":dotnet_sdk"
 )
 
 filegroup(

--- a/dotnet/private/toolchain/nuget.bzl
+++ b/dotnet/private/toolchain/nuget.bzl
@@ -92,7 +92,11 @@ def _nuget_fetch_impl(ctx):
         # it's possible that the packages folder doesn't exist yet, if it doesn't the symlink won't be functional
         # this mostly likely won't be the case in actual usage, but is definitely possible if the folder has been
         # cleaned, like on a fresh CI instance for example.
-        makeres = ctx.execute(["mkdir", location])
+        makeres = ctx.execute([
+            "mkdir",
+            "/S" if os == "windows" else "-p",
+            location,
+        ])
         ctx.symlink(location, config.packages_folder)
 
         res1 = ctx.execute(["dir", location])

--- a/dotnet/private/toolchain/nuget.bzl
+++ b/dotnet/private/toolchain/nuget.bzl
@@ -551,7 +551,6 @@ def _generate_build_files(ctx, config):
         ctx.attr._root_template,
         substitutions = {
             "{test_logger}": test_logger,
-            # todo(#61) explicitly develop the file list.
             "{file_list}": _json_bzl(all_all_files, ""),
             "{nuget_build_config}": NUGET_BUILD_CONFIG,
             "{tfm_mapping}": _json_bzl(config.tfm_mapping),

--- a/dotnet/private/toolchain/nuget.bzl
+++ b/dotnet/private/toolchain/nuget.bzl
@@ -94,7 +94,7 @@ def _nuget_fetch_impl(ctx):
         # cleaned, like on a fresh CI instance for example.
         mkdir = None
         if os == "windows":
-            mkdir = ["cmd","/e:on" "/c", "mkdir " + location]
+            mkdir = ["cmd", "/e:on", "/c", "mkdir " + location]
         else:
             mkdir = ["mkdir", "-p", location]
 

--- a/dotnet/private/toolchain/nuget.bzl
+++ b/dotnet/private/toolchain/nuget.bzl
@@ -92,11 +92,13 @@ def _nuget_fetch_impl(ctx):
         # it's possible that the packages folder doesn't exist yet, if it doesn't the symlink won't be functional
         # this mostly likely won't be the case in actual usage, but is definitely possible if the folder has been
         # cleaned, like on a fresh CI instance for example.
-        makeres = ctx.execute([
-            "mkdir",
-            "/S" if os == "windows" else "-p",
-            location,
-        ])
+        mkdir = None
+        if os == "windows":
+            mkdir = ["cmd","/e:on" "/c", "mkdir " + location]
+        else:
+            mkdir = ["mkdir", "-p", location]
+
+        makeres = ctx.execute(mkdir)
         ctx.symlink(location, config.packages_folder)
 
         res1 = ctx.execute(["dir", location])

--- a/dotnet/private/toolchain/nuget.bzl
+++ b/dotnet/private/toolchain/nuget.bzl
@@ -95,6 +95,11 @@ def _nuget_fetch_impl(ctx):
         ctx.execute(["mkdir", location])
         ctx.symlink(location, config.packages_folder)
 
+        res1 = ctx.execute(["dir", location])
+        res2 = ctx.execute(["dir", config.packages_folder])
+
+        fail("\n".join([res1.stdout, res1.stderr, "----------------------------", res2.stdout, res2.stderr]))
+
     _generate_nuget_configs(ctx, config)
     fetch_project = _generate_fetch_project(ctx, config)
 

--- a/dotnet/private/toolchain/nuget.bzl
+++ b/dotnet/private/toolchain/nuget.bzl
@@ -61,15 +61,37 @@ def _nuget_fetch_impl(ctx):
         all_files = [],
         tfm_mapping = {},
     )
-
-    _generate_nuget_configs(ctx, config)
-    fetch_project = _generate_fetch_project(ctx, config)
-
     os, _ = detect_host_platform(ctx)
     dotnet = dotnet_context(
         str(ctx.path(ctx.attr.dotnet_sdk_root).dirname),
         os,
     )
+
+    if ctx.attr.use_host:
+        # https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-nuget-locals
+        cache_type = "global-packages"
+        args = [
+            dotnet.path,
+            "nuget",
+            "locals",
+            cache_type,
+            "--list",
+        ]
+        result = ctx.execute(args)
+        if result.return_code != 0:
+            fail("failed to find global-packages folder with dotnet: " + result.stderr)
+
+        # example dotnet5 output: `global-packages: /Users/samh/.nuget/packages/`
+        # example dotnet3.1 output: `info : global-packages: /Users/samh/.nuget/packages/`
+        ind = result.stdout.index(cache_type)
+        if ind < 0:
+            fail("unexpected output from {}: {}".format(" ".join(args), result.stdout))
+        start = ind + len(cache_type) + 2
+        location = result.stdout[start:].strip()
+        ctx.symlink(location, config.packages_folder)
+
+    _generate_nuget_configs(ctx, config)
+    fetch_project = _generate_fetch_project(ctx, config)
 
     args, _ = make_cmd(
         dotnet,
@@ -506,7 +528,8 @@ def _get_overrides(ctx, dotnet, tfn):
 def _generate_build_files(ctx, config):
     all_all_files = []
     for pkg in config.packages.values():
-        all_all_files.append(pkg.all_files)
+        # these are labels, and we need them to be paths to be used for exports_files()
+        all_all_files.extend([f[3:] for f in pkg.all_files])
         ctx.template(
             ctx.path(paths.join(pkg.name, "BUILD.bazel")),
             ctx.attr._nuget_import_template,
@@ -529,11 +552,14 @@ def _generate_build_files(ctx, config):
         substitutions = {
             "{test_logger}": test_logger,
             # todo(#61) explicitly develop the file list.
-            "{file_list}": "",
+            "{file_list}": _json_bzl(all_all_files, ""),
             "{nuget_build_config}": NUGET_BUILD_CONFIG,
-            "{tfm_mapping}": json.encode_indent(config.tfm_mapping, prefix = "    ", indent = "    "),
+            "{tfm_mapping}": _json_bzl(config.tfm_mapping),
         },
     )
+
+def _json_bzl(obj, prefix = "    "):
+    return json.encode_indent(obj, prefix = prefix, indent = "    ")
 
 nuget_fetch = repository_rule(
     implementation = _nuget_fetch_impl,
@@ -547,6 +573,12 @@ nuget_fetch = repository_rule(
             default = Label("@dotnet_sdk//:ROOT"),
             executable = True,
             cfg = "exec",
+        ),
+        "use_host": attr.bool(
+            default = False,
+            doc = ("When false (default) nuget packages will be fetched into a bazel-only directory, when true, the " +
+                   "host machine's global packages folder will be used. This is determined by executing " +
+                   "`dotnet nuget locals global-packages --list"),
         ),
         "_master_template": attr.label(
             default = Label("@my_rules_dotnet//dotnet/private/msbuild:project.tpl.proj"),

--- a/dotnet/private/toolchain/nuget.bzl
+++ b/dotnet/private/toolchain/nuget.bzl
@@ -92,13 +92,13 @@ def _nuget_fetch_impl(ctx):
         # it's possible that the packages folder doesn't exist yet, if it doesn't the symlink won't be functional
         # this mostly likely won't be the case in actual usage, but is definitely possible if the folder has been
         # cleaned, like on a fresh CI instance for example.
-        ctx.execute(["mkdir", location])
+        makeres = ctx.execute(["mkdir", location])
         ctx.symlink(location, config.packages_folder)
 
         res1 = ctx.execute(["dir", location])
         res2 = ctx.execute(["dir", config.packages_folder])
 
-        fail("\n".join([res1.stdout, res1.stderr, "----------------------------", res2.stdout, res2.stderr]))
+        fail("\n".join([makeres.stdout, makeres.stderr, res1.stdout, res1.stderr, "----------------------------", res2.stdout, res2.stderr]))
 
     _generate_nuget_configs(ctx, config)
     fetch_project = _generate_fetch_project(ctx, config)

--- a/dotnet/private/toolchain/nuget.bzl
+++ b/dotnet/private/toolchain/nuget.bzl
@@ -88,6 +88,11 @@ def _nuget_fetch_impl(ctx):
             fail("unexpected output from {}: {}".format(" ".join(args), result.stdout))
         start = ind + len(cache_type) + 2
         location = result.stdout[start:].strip()
+
+        # it's possible that the packages folder doesn't exist yet, if it doesn't the symlink won't be functional
+        # this mostly likely won't be the case in actual usage, but is definitely possible if the folder has been
+        # cleaned, like on a fresh CI instance for example.
+        ctx.execute(["mkdir", location])
         ctx.symlink(location, config.packages_folder)
 
     _generate_nuget_configs(ctx, config)

--- a/dotnet/private/toolchain/nuget.bzl
+++ b/dotnet/private/toolchain/nuget.bzl
@@ -98,13 +98,8 @@ def _nuget_fetch_impl(ctx):
         else:
             mkdir = ["mkdir", "-p", location]
 
-        makeres = ctx.execute(mkdir)
+        ctx.execute(mkdir)
         ctx.symlink(location, config.packages_folder)
-
-        res1 = ctx.execute(["dir", location])
-        res2 = ctx.execute(["dir", config.packages_folder])
-
-        fail("\n".join([makeres.stdout, makeres.stderr, res1.stdout, res1.stderr, "----------------------------", res2.stdout, res2.stderr]))
 
     _generate_nuget_configs(ctx, config)
     fetch_project = _generate_fetch_project(ctx, config)


### PR DESCRIPTION
This may be considered not very bazel-like, but nuget appears to do just fine with managing multiple versions of the same package, so we shouldn't have to worry about getting the wrong package. We are still precisely analyzing the package files as well, so we are not requesting any other package versions.

Closes #57
Closes #61 